### PR TITLE
Optimize/reset time index

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,18 +40,17 @@ return {
 
 ## How to use
 
-Just hit `<C-q>` repeatedly (while in insert mode) until you come across a date you like.
+Just hit `<C-t>` repeatedly (while in insert mode) until you come across a date you like.
 
 ## Configuration
 
-No real configuration. Right now the function just a keymap that calls the function.
-Can be overridden pretty easily.
+No real configuration. A keymap that calls the function to cycle through the time.
 
-Place something like this in your `keymaps.lua` or where ever you keep your mappings:
+To override, place something like this in your `keymaps.lua` or where ever you keep your mappings:
 
 ```
-# To override just pass in the keymap of your choice. Like if it is: <C-t>
-vim.keymap.set("i", "<C-t>", "<Cmd>lua cycle_date_format()<CR>", { noremap = true })
+# This changed the keymap to <C-o> and enables it in normal mode
+vim.keymap.set("n", "<C-o>", "<Cmd>lua cycle_date_format()<CR>", { noremap = true })
 ```
 
 ## Why this plugin?

--- a/plugin/chronos.lua
+++ b/plugin/chronos.lua
@@ -1,9 +1,10 @@
-print("Chronos loaded in due time")
+print("Chronos loaded in just in time")
 
 local date_formats = {
   "%Y-%m-%d",
   "%Y/%m/%d",
-  "%d/%m/%Y",
+  "%m-%d-%Y",
+  "%m/%d/%Y",
 }
 
 local current_format_index = 1
@@ -27,6 +28,7 @@ function cycle_date_format()
 end
 
 function reset_feature()
+  current_format_index = 1
   last_inserted_text = ""
 end
 

--- a/plugin/chronos.lua
+++ b/plugin/chronos.lua
@@ -32,6 +32,6 @@ function reset_feature()
   last_inserted_text = ""
 end
 
-vim.keymap.set("i", "<C-q>", "<Cmd>lua cycle_date_format()<CR>", { noremap = true })
+vim.keymap.set("i", "<C-t>", "<Cmd>lua cycle_date_format()<CR>", { noremap = true })
 vim.cmd("autocmd InsertCharPre * lua reset_feature()")
 


### PR DESCRIPTION
- Updates the `reset_feature()` function to reassign the current time format back to initial index. So now when you choose your preferred time format and continue typing, when you go to add another timestamp in your document it will cycle through the formats from the beginning.

- Also added a new format and updated an existing one. Current options for time formats are:
```
  "%Y-%m-%d",
  "%Y/%m/%d",
  "%m-%d-%Y",
  "%m/%d/%Y",
```
- Changes default keymap to `<C-t>`. "T" for time. That simple.

