### PR TITLE
Update chronos.lua

### DIFF
--- a/plugin/chronos.lua
+++ b/plugin/chronos.lua
@@ -30,6 +30,6 @@ function reset_feature()
   last_inserted_text = ""
 end
 
-vim.keymap.set("i", "<C-t>", "<Cmd>lua cycle_date_format()<CR>", { noremap = true })
+vim.keymap.set("n", "<C-t>", "<Cmd>lua cycle_date_format()<CR>", { noremap = true })
 vim.cmd("autocmd InsertCharPre * lua reset_feature()")
 


### PR DESCRIPTION
Updated default keymap to run in normal mode. Works on vim command as well.